### PR TITLE
add option for renderComponentToString

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ option | values | default
 `jsx.harmony` | `true`: enable a subset of ES6 features | `false`
 `jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
+`static` | `true`: render the component with `renderComponentToStaticMarkup` otherwise `renderComponentToString` | `true`
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ var DEFAULT_OPTIONS = {
     extension: '.jsx',
     harmony: false
   },
-  doctype: '<!DOCTYPE html>'
+  doctype: '<!DOCTYPE html>',
+  static: true
 };
 
 function createEngine(engineOptions) {
@@ -31,8 +32,10 @@ function createEngine(engineOptions) {
   function renderFile(filename, options, cb) {
     try {
       var markup = engineOptions.doctype;
-      var component = require(filename);
-      markup += React.renderComponentToStaticMarkup(component(options));
+      var component = require(filename)(options);
+
+      if (engineOptions.static) markup += React.renderComponentToStaticMarkup(component);
+      else markup += React.renderComponentToString(component);
     } catch (e) {
       return cb(e);
     }


### PR DESCRIPTION
Add ability to render on the server and skip rerendering on client. 

http://facebook.github.io/react/docs/top-level-api.html#react.rendercomponenttostring
