### PR TITLE
Fixes loading modules from transpiled es6.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function createEngine(engineOptions) {
     try {
       var markup = engineOptions.doctype;
       var component = require(filename);
+      // Transpiled ES6 may export components as { default: Component }
+      component = component.default || component;
       markup += React.renderComponentToStaticMarkup(component(options));
     } catch (e) {
       return cb(e);


### PR DESCRIPTION
In many es6 transpilers, `export default Component` creates the syntax `module.export = { default: Component }`. This adds a check so that if a `require`d component contains a `default` property, it is used.

We could be paranoid and check `typeof component` to see if it's a `function` or an `object`, but that's probably overkill.
