### PR TITLE
render components ready to be mounted on the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ option | values | default
 `jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`
+`static` | `true`: component won't be ready to mount if using `react` on the browser (note, this generates less markup) | `true`
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ var DEFAULT_OPTIONS = {
     harmony: false
   },
   doctype: '<!DOCTYPE html>',
-  beautify: false
+  beautify: false,
+  static: true
 };
 
 function createEngine(engineOptions) {
@@ -36,7 +37,14 @@ function createEngine(engineOptions) {
       var component = require(filename);
       // Transpiled ES6 may export components as { default: Component }
       component = component.default || component;
-      markup += React.renderComponentToStaticMarkup(component(options));
+
+      var instance = component(options);
+
+      if (engineOptions.static) {
+        markup += React.renderComponentToStaticMarkup(instance);
+      } else {
+        markup += React.renderComponentToString(instance);
+      }
     } catch (e) {
       return cb(e);
     }


### PR DESCRIPTION
By passing a new option flag `static` (defaults to `true`) we can toggle between rendering components with and without react extra markup.
