### PR TITLE
lodash.merge module causes problems with Windows path length limitation

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
 var React = require('react');
 var beautifyHTML = require('js-beautify').html;
 var nodeJSX = require('node-jsx');
-var _merge = require('lodash.merge');
+var _merge = require('lodash').merge;
 
 var DEFAULT_OPTIONS = {
   jsx: {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ini": "^1.3.2",
     "install": "^0.1.8",
     "js-beautify": "^1.4.2",
-    "jstransform": "^7.0.0",
+    "jstransform": "^8.2.0",
     "lodash": "^2.4.1",
     "lru-cache": "^2.5.0",
     "minimatch": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "react-tools": "^0.12.0",
     "node-jsx": "^0.12.0",
     "js-beautify": "^1.4.2",
-    "lodash.merge": "^2.4.1"
+    "lodash": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,42 @@
     "url": "https://github.com/reactjs/express-react-views.git"
   },
   "license": "BSD-3-Clause",
-  "peerDependencies": {
-    "react": "^0.12.0"
-  },
   "dependencies": {
-    "react-tools": "^0.12.0",
-    "node-jsx": "^0.12.0",
+    "abbrev": "^1.0.5",
+    "amdefine": "^0.1.0",
+    "ast-types": "^0.6.6",
+    "base62": "^0.1.1",
+    "commander": "^2.5.0",
+    "commoner": "^0.10.1",
+    "config-chain": "^1.1.8",
+    "envify": "^3.2.0",
+    "esprima-fb": "^8001.1001.0-dev-harmony-fb",
+    "glob": "^4.2.2",
+    "graceful-fs": "^3.0.5",
+    "iconv-lite": "^0.4.5",
+    "inflight": "^1.0.4",
+    "inherits": "^2.0.1",
+    "ini": "^1.3.2",
+    "install": "^0.1.8",
     "js-beautify": "^1.4.2",
-    "lodash": "^2.4.1"
+    "jstransform": "^7.0.0",
+    "lodash": "^2.4.1",
+    "lru-cache": "^2.5.0",
+    "minimatch": "^1.0.0",
+    "minimist": "0.0.8",
+    "mkdirp": "^0.5.0",
+    "node-jsx": "^0.12.0",
+    "nopt": "^3.0.1",
+    "once": "^1.3.1",
+    "private": "^0.1.6",
+    "proto-list": "^1.2.3",
+    "q": "^1.1.2",
+    "react": "^0.12.0",
+    "react-tools": "^0.12.0",
+    "recast": "^0.9.9",
+    "sigmund": "^1.0.0",
+    "source-map": "^0.1.31",
+    "through": "^2.3.6",
+    "wrappy": "^1.0.1"
   }
 }


### PR DESCRIPTION
See this discussing for background: https://github.com/joyent/node/issues/6960

The lodash.merge module causes a very deep folder structure that gives problems in Windows. Filepaths can be no longer than 260 characters. 

As a result we are not able to use Nuget to package and deploy our NodeJS server due to this problem.