### PR TITLE
Fix missing semicolon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ var HelloMessage = React.createClass({
   }
 });
 
-module.exports = HelloMessage
+module.exports = HelloMessage;
 ```
 
 ### Routes


### PR DESCRIPTION
There was a missing ; after `module.exports = HelloMessage;`