### PR TITLE
Bump version of react 'peerDependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "react": "^0.13.1"
+    "react": "^0.13.0"
   },
   "dependencies": {
     "js-beautify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "react": "^0.12.0"
+    "react": "^0.13.1"
   },
   "dependencies": {
     "js-beautify": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-3-Clause",
   "peerDependencies": {
-    "react": "^0.13.0"
+    "react": ">=0.12.0"
   },
   "dependencies": {
     "js-beautify": "^1.5.4",


### PR DESCRIPTION
It also may solve the `npm ERR! peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!`