### PR TITLE
Added the ability to produce non-static markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ option | values | default
 `jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`
+`static` | `true`: render markup which does not include the `data-react-checksum` or `data-reactid` fields | `true`
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ var DEFAULT_OPTIONS = {
     stripTypes: false
   },
   doctype: '<!DOCTYPE html>',
-  beautify: false
+  beautify: false,
+  static: true
 };
 
 function createEngine(engineOptions) {
@@ -44,8 +45,13 @@ function createEngine(engineOptions) {
       var component = require(filename);
       // Transpiled ES6 may export components as { default: Component }
       component = component.default || component;
-      markup +=
-        React.renderToStaticMarkup(React.createElement(component, options));
+      if (engineOptions.static) {
+        markup +=
+          React.renderToStaticMarkup(React.createElement(component, options));
+      } else {
+        markup +=
+          React.renderToString(React.createElement(component, options));
+      }
     } catch (e) {
       return cb(e);
     }


### PR DESCRIPTION
I hope that this can finally be a compromise on this whole static vs non-static issue. This does not in any way change the statement that this project does not support mounting of views on the client, but rather enables someone to figure that out themselves while still being able to use this package out of the box.