### PR TITLE
Requiring React is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ app.engine('jsx', require('express-react-views').createEngine(options));
 Your views should be node modules that export a React component. Let's assume you have this file in `views/index.jsx`:
 
 ```js
+var React = require('react');
+
 var HelloMessage = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -84,6 +86,8 @@ Simply pass the relevant props to a layout component.
 
 `views/layouts/default.jsx`:
 ```js
+var React = require('react');
+
 var DefaultLayout = React.createClass({
   render: function() {
     return (
@@ -100,6 +104,7 @@ module.exports = DefaultLayout;
 
 `views/index.jsx`:
 ```js
+var React = require('react');
 var DefaultLayout = require('./layouts/default');
 
 var HelloMessage = React.createClass({


### PR DESCRIPTION
From the examples, it seems that it's going to resolve `React` automatically but it doesn't.