### PR TITLE
Switch from node-jsx to babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ app.engine('jsx', require('express-react-views').createEngine());
 Beginning with v0.2, you can now pass options in when creating your engine.
 
 option | values | default
-`jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 
 ```js
-var options = { jsx: { harmony: true } };
+var options = { beautify: true };
 app.engine('jsx', require('express-react-views').createEngine(options));
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install express-react-views react
 
 var app = express();
 
+app.set('views', __dirname + '/views');
 app.set('view engine', 'jsx');
 app.engine('jsx', require('express-react-views').createEngine());
 ```
@@ -41,6 +42,8 @@ app.engine('jsx', require('express-react-views').createEngine(options));
 
 
 ### Views
+
+Under the hood, [Babel][babel] is used to compile your views into ES5 friendly code, using the default Babel options.  Only the files in your `views` directory (`app.set('views', __dirname + '/views')`) will be compiled.
 
 Your views should be node modules that export a React component. Let's assume you have this file in `views/index.jsx`:
 
@@ -155,3 +158,4 @@ All "locals" are exposed to your view in `this.props`. These should work identic
 [jade]: http://jade-lang.com/
 [ejs]: http://embeddedjs.com/
 [hbs]: https://github.com/barc/express-hbs
+[babel] https://babeljs.io/

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ app.engine('jsx', require('express-react-views').createEngine());
 Beginning with v0.2, you can now pass options in when creating your engine.
 
 option | values | default
--------|--------|--------
-`jsx.harmony` | `true`: enable a subset of ES6 features | `false`
-`jsx.stripTypes` | `true`: strip [Flow](http://flowtype.org/) type annotations | `false`
 `jsx.extension` | any file extension with leading `.` | `".jsx"`
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ app.engine('jsx', require('express-react-views').createEngine(options));
 
 ### Views
 
-Under the hood, [Babel][babel] is used to compile your views into ES5 friendly code, using the default Babel options.  Only the files in your `views` directory (`app.set('views', __dirname + '/views')`) will be compiled.
+Under the hood, [Babel][babel] is used to compile your views into ES5 friendly code, using the default Babel options.  Only the files in your `views` directory (i.e. `app.set('views', __dirname + '/views')`) will be compiled.
 
 Your views should be node modules that export a React component. Let's assume you have this file in `views/index.jsx`:
 

--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ All "locals" are exposed to your view in `this.props`. These should work identic
 [jade]: http://jade-lang.com/
 [ejs]: http://embeddedjs.com/
 [hbs]: https://github.com/barc/express-hbs
-[babel] https://babeljs.io/
+[babel]: https://babeljs.io/

--- a/examples/dynamic/app.js
+++ b/examples/dynamic/app.js
@@ -4,11 +4,7 @@ var reactViews = require('express-react-views');
 var app = express();
 
 app.set('view engine', 'js');
-app.engine('js', reactViews.createEngine({
-  jsx: {
-    extension: '.js'
-  }
-}));
+app.engine('js', reactViews.createEngine());
 
 app.use(express.static(__dirname + '/public'));
 

--- a/examples/simple/app.js
+++ b/examples/simple/app.js
@@ -19,12 +19,7 @@ var app = express();
 app.set('port', process.env.PORT || 3000);
 app.set('views', __dirname + '/views');
 app.set('view engine', 'jsx');
-app.engine('jsx', reactViews.createEngine({
-  jsx: {
-    harmony: true,
-    stripTypes: true
-  }
-}));
+app.engine('jsx', reactViews.createEngine());
 app.use(express.favicon());
 app.use(express.logger('dev'));
 app.use(express.bodyParser());

--- a/index.js
+++ b/index.js
@@ -9,14 +9,11 @@
 
 var React = require('react');
 var beautifyHTML = require('js-beautify').html;
-var nodeJSX = require('node-jsx');
 var assign = require('object-assign');
 
 var DEFAULT_OPTIONS = {
   jsx: {
-    extension: '.jsx',
-    harmony: false,
-    stripTypes: false
+    extension: '.jsx'
   },
   doctype: '<!DOCTYPE html>',
   beautify: false
@@ -32,9 +29,7 @@ function createEngine(engineOptions) {
   // Since we're passing an object with jsx as the key, it'll override the rest.
   engineOptions = assign({}, DEFAULT_OPTIONS, engineOptions, {jsx: jsxOptions});
 
-  // Don't install the require until the engine is created. This lets us leave
-  // the option of using harmony features up to the consumer.
-  nodeJSX.install(engineOptions.jsx);
+  require('babel/register');
 
   var moduleDetectRegEx = new RegExp('\\' + engineOptions.jsx.extension + '$');
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@
 var React = require('react');
 var beautifyHTML = require('js-beautify').html;
 var assign = require('object-assign');
-var registered = false;
 
 var DEFAULT_OPTIONS = {
   doctype: '<!DOCTYPE html>',
@@ -18,9 +17,10 @@ var DEFAULT_OPTIONS = {
 };
 
 function createEngine(engineOptions) {
-  engineOptions = assign({}, DEFAULT_OPTIONS, engineOptions || {});
-
+  var registered = false;
   var moduleDetectRegEx;
+
+  engineOptions = assign({}, DEFAULT_OPTIONS, engineOptions || {});
 
   function renderFile(filename, options, cb) {
     // Defer babel registration until the first request so we can grab the view path.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "js-beautify": "^1.5.4",
-    "node-jsx": "^0.12.0",
+    "babel": "^5.1.13",
     "object-assign": "^2.0.0",
     "react-tools": "^0.12.2"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test"
   },
   "author": "Paul O’Shannessy <paul@oshannessy.com>",
   "repository": {
@@ -25,5 +25,9 @@
     "babel": "^5.1.13",
     "object-assign": "^2.0.0",
     "react-tools": "^0.12.2"
+  },
+  "devDependencies": {
+    "react": "^0.13.2",
+    "async": "^0.9.0"
   }
 }

--- a/test/es5-component.jsx
+++ b/test/es5-component.jsx
@@ -1,0 +1,30 @@
+var React = require('react');
+
+function countTo(n) {
+  var a = [];
+  for (var i = 0; i < n; i++ ) {
+    a.push(i + 1);
+  }
+  return a.join(', ');
+}
+
+var Index = React.createClass({
+  propTypes: {
+    title: React.PropTypes.string
+  },
+
+  render: function() {
+    return (
+      <div>
+        <h1>{this.props.title}</h1>
+        <p>Welcome to {this.props.title}</p>
+        <p>
+          I can count to 10:
+          {countTo(10)}
+        </p>
+      </div>
+    );
+  }
+});
+
+module.exports = Index;

--- a/test/es6-component.jsx
+++ b/test/es6-component.jsx
@@ -9,12 +9,6 @@ function countTo(n) {
 }
 
 class Index = extends React.Component {
-  static propTypes() {
-    return {
-      title: React.PropTypes.string
-    };
-  }
-
   render() {
     return (
       <div>
@@ -28,5 +22,9 @@ class Index = extends React.Component {
     );
   }
 }
+
+Index.propTypes = {
+  title: React.PropTypes.string
+};
 
 module.exports = Index;

--- a/test/es6-component.jsx
+++ b/test/es6-component.jsx
@@ -1,0 +1,32 @@
+const React = require('react');
+
+function countTo(n) {
+  var a = [];
+  for (var i = 0; i < n; i++ ) {
+    a.push(i + 1);
+  }
+  return a.join(', ');
+}
+
+class Index = extends React.Component {
+  static propTypes() {
+    return {
+      title: React.PropTypes.string
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>{this.props.title}</h1>
+        <p>Welcome to {this.props.title}</p>
+        <p>
+          I can count to 10:
+          {countTo(10)}
+        </p>
+      </div>
+    );
+  }
+}
+
+module.exports = Index;

--- a/test/es6-flow-component.jsx
+++ b/test/es6-flow-component.jsx
@@ -1,0 +1,33 @@
+const React = require('react');
+
+// Contrived example to show how one might use Flow type annotations
+function countTo(n:number):string {
+  var a = [];
+  for (var i = 0; i < n; i++ ) {
+    a.push(i + 1);
+  }
+  return a.join(', ');
+}
+
+class Index = extends React.Component {
+  static propTypes() {
+    return {
+      title: React.PropTypes.string
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>{this.props.title}</h1>
+        <p>Welcome to {this.props.title}</p>
+        <p>
+          I can count to 10:
+          {countTo(10)}
+        </p>
+      </div>
+    );
+  }
+}
+
+module.exports = Index;

--- a/test/es6-flow-component.jsx
+++ b/test/es6-flow-component.jsx
@@ -10,12 +10,6 @@ function countTo(n:number):string {
 }
 
 class Index = extends React.Component {
-  static propTypes() {
-    return {
-      title: React.PropTypes.string
-    };
-  }
-
   render() {
     return (
       <div>
@@ -29,5 +23,9 @@ class Index = extends React.Component {
     );
   }
 }
+
+Index.propTypes = {
+  title: Read.PropTypes.string
+};
 
 module.exports = Index;

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,8 @@ var async = require('async');
 var viewEngine = require('..');
 var viewOptions = {
   settings: {
-    env: 'development'
+    env: 'development',
+    views: __dirname
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+var async = require('async');
+var viewEngine = require('..');
+var viewOptions = {
+  settings: {
+    env: 'development'
+  }
+};
+
+function testComponent(path, cb) {
+  var render = viewEngine.createEngine();
+  render(__dirname + '/es5-component.jsx', viewOptions, function(err, source) {
+    assert(!err);
+    assert(source.indexOf('I can count to 10:1, 2, 3, 4, 5, 6, 7, 8, 9, 10') !== -1);
+    cb();
+  });
+}
+
+async.series([
+  function testES5Module(next) {
+    testComponent(__dirname + '/es5-component.jsx', next);
+  },
+  function testES6Module(next) {
+    testComponent(__dirname + '/es6-component.jsx', next);
+  },
+  function testES6FlowModule(next) {
+    testComponent(__dirname + '/es6-flow-component.jsx', next);
+  }
+], function done() {
+  console.log('All tests pass!');
+  process.exit(0);
+});
+


### PR DESCRIPTION
Babel appears to be the future of ES6 transpiling, and has built-in jsx support, so I think it makes sense to switch over to it from node-jsx.

This pull does change/kinda break a few things:

- `jsx.harmony`.  Obviously if we're using babel, ES6 features will be allowed, so this option no longer makes sense.
- `jsx.stripTypes`.  Babel automatically strips out flow types, although that can be opted out of.  Maybe I should implement that, in which case keeping this setting makes sense?

I also added some very basic tests, to make sure everything still worked.