### PR TITLE
Loosen the RegEx that ends up getting used by Babel for views

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,10 @@ function createEngine(engineOptions) {
     // Defer babel registration until the first request so we can grab the view path.
     if (!registered) {
       moduleDetectRegEx = new RegExp('^' + options.settings.views);
+      // Passing a RegExp to Babel results in an issue on Windows so we'll just
+      // pass the view path.
       require('babel/register')({
-        only: moduleDetectRegEx
+        only: options.settings.views
       });
       registered = true;
     }


### PR DESCRIPTION
Fixes #33.

@xuteng, would you be willing to test this? I know you found another similar solution but I wanted to see if this would work. It does work on OS X at least, but Windows paths might still be an issue.