### PR TITLE
support client side Reactjs without re-render when initial if server side already rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.10.0 (2015-10-27)
+
+* support checksum for client side.
+* fix es6 test components.
+* add checksum test for all test case.
+
 # v0.9.0 (2015-10-08)
 
 * Update to React v0.14, drop support for React v0.12-0.13

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ option | values | default
 `doctype` | any string that can be used as [a doctype](http://en.wikipedia.org/wiki/Document_type_declaration), this will be prepended to your document | `"<!DOCTYPE html>"`
 `beautify` | `true`: beautify markup before outputting (note, this can affect rendering due to additional whitespace) | `false`
 `transformViews` | `true`: use `babel` to apply JSX, ESNext transforms to views.<br>**Note:** if already using `babel/register` in your project, you should set this to `false` | `true`
+`checksum` | `false`: if you set `true`, it will add new attribute `data-react-checksum` on your dom, and client side will check on init and no re-render
 
 The defaults are sane, but just in case you want to change something, here's how it would look:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-react-views",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "This is an Express view engine which renders React components on server. It renders static markup and *does not* support mounting those views on the client.",
   "keywords": [
     "express",

--- a/test/es6-component.jsx
+++ b/test/es6-component.jsx
@@ -8,7 +8,7 @@ function countTo(n) {
   return a.join(', ');
 }
 
-class Index = extends React.Component {
+class Index extends React.Component {
   render() {
     return (
       <div>

--- a/test/es6-flow-component.jsx
+++ b/test/es6-flow-component.jsx
@@ -9,7 +9,7 @@ function countTo(n:number):string {
   return a.join(', ');
 }
 
-class Index = extends React.Component {
+class Index extends React.Component {
   render() {
     return (
       <div>
@@ -25,7 +25,7 @@ class Index = extends React.Component {
 }
 
 Index.propTypes = {
-  title: Read.PropTypes.string
+  title: React.PropTypes.string
 };
 
 module.exports = Index;

--- a/test/index.js
+++ b/test/index.js
@@ -8,11 +8,21 @@ var viewOptions = {
   }
 };
 
-function testComponent(path, cb) {
-  var render = viewEngine.createEngine();
-  render(__dirname + '/es5-component.jsx', viewOptions, function(err, source) {
+function getEngine(checksum){
+  var options = checksum===true ? {checksum:true}:{};
+  return viewEngine.createEngine(options);
+}
+
+function testComponent(path, cb, checksum) {
+  var render = getEngine(checksum);
+  render(path, viewOptions, function(err, source) {
     assert(!err);
-    assert(source.indexOf('I can count to 10:1, 2, 3, 4, 5, 6, 7, 8, 9, 10') !== -1);
+    
+    if(checksum){
+      assert(source.indexOf('I can count to 10:</span>') !== -1 && source.indexOf('1, 2, 3, 4, 5, 6, 7, 8, 9, 10') !== -1);
+    }else{
+      assert(source.indexOf('I can count to 10:1, 2, 3, 4, 5, 6, 7, 8, 9, 10') !== -1);
+    }
     cb();
   });
 }
@@ -26,6 +36,15 @@ async.series([
   },
   function testES6FlowModule(next) {
     testComponent(__dirname + '/es6-flow-component.jsx', next);
+  },
+  function testChecksumES5Module(next) {
+    testComponent(__dirname + '/es5-component.jsx', next, true);
+  },
+  function testChecksumES6Module(next) {
+    testComponent(__dirname + '/es6-component.jsx', next, true);
+  },
+  function testChecksumES6FlowModule(next) {
+    testComponent(__dirname + '/es6-flow-component.jsx', next, true);
   }
 ], function done() {
   console.log('All tests pass!');


### PR DESCRIPTION
support client side Reactjs without re-render when initial if server side already rendered

It works like this:

1. Setting options.checksum is 'true' when create express view engine, 
2. The index.js will checking this flag to output the markup with mathod 'ReactDOMServer.renderToString' or 'ReactDOMServer.renderToStaticMarkup'.
3. On the client side, Reactjs checks if the markup generated by your component matches the checksum and simple returns(client side init and no re-render)