### PR TITLE
Check for Modules Existence Before Deleting

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function createEngine(engineOptions) {
       if (options.settings.env === 'development') {
         // Remove all files from the module cache that are in the view folder.
         Object.keys(require.cache).forEach(function(module) {
-          if (moduleDetectRegEx.test(require.cache[module].filename)) {
+          if (module && moduleDetectRegEx.test(require.cache[module].filename)) {
             delete require.cache[module];
           }
         });


### PR DESCRIPTION
We have some weird issue at PayPal where we see this `module` variable as `undefined` and it will blow up, but only when we have the `webpack` `eslint` plugin enabled. I don't know why it is, but this fixes the issue, assume `eslint` messes with the `require.cache` or something? A bit weird, but wondering if you'd consider this change (or not).
