### PR TITLE
Handle case where options.settings.views is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,14 @@ function createEngine(engineOptions) {
     // Defer babel registration until the first request so we can grab the view path.
     if (!moduleDetectRegEx) {
       // Path could contain regexp characters so escape it first.
-      moduleDetectRegEx = new RegExp('^' + _escaperegexp(options.settings.views));
+      // options.settings.views could be a single string or an array      
+      moduleDetectRegEx = new RegExp(
+        [].concat(options.settings.views)
+        .map(viewPath => '^' + _escaperegexp(viewPath))
+        .join('|')
+      );    
     }
+    
     if (engineOptions.transformViews && !registered) {
       // Passing a RegExp to Babel results in an issue on Windows so we'll just
       // pass the view path.


### PR DESCRIPTION
Proposed solution for issue #108 

If an array of paths is passed, make each a regex clause and concatenate with | operator.